### PR TITLE
Fixed bug: empty contexts object

### DIFF
--- a/js/pdjs.js
+++ b/js/pdjs.js
@@ -154,7 +154,6 @@
       }
       params.data.description = params.data.description || params.description || "No description provided";
       params.data.details = params.data.details || params.details || {};
-      params.data.contexts = params.data.contexts || params.contexts || {};
       params.data = JSON.stringify(params.data);
       params.contentType = "application/json; charset=utf-8";
       params.dataType = "json";


### PR DESCRIPTION
The v1 Events API responds with 400 Bad Request when sending it an event payload that has an empty contexts object. This object should simply be omitted if it is blank/unspecified.