### PR TITLE
Devi 990 update deprecated circleci images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   base:
     docker:
-      - image: cimg/node:14
+      - image: cimg/node:14.18
     working_directory: /home/circleci/pdjs
 
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,7 +3,7 @@ version: 2.1
 executors:
   base:
     docker:
-      - image: circleci/node:14
+      - image: cimg/node:14
     working_directory: /home/circleci/pdjs
 
 jobs:


### PR DESCRIPTION
DEVI-990 - https://pagerduty.atlassian.net/browse/DEVI-990
Slack post about deprecation and changed needed: https://pagerduty.slack.com/archives/C07Q87V3L/p1641339422441100

CircleCI released new images, and have deprecated old ones: https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

Requires change to circleci config, to use next gen images going forward.

Test:

- [ ]  Confirm CircleCI jobs worked successfully