### PR TITLE
Fix array query parameters are not serialized properly

### DIFF
--- a/src/common.ts
+++ b/src/common.ts
@@ -106,7 +106,7 @@ function applyParameters(url: URL, queryParameters?: QueryParameter): URL {
     if (Array.isArray(parameter)) {
       // Support for array based keys like `additional_fields[]`
       parameter.forEach(item => {
-        combinedParameters.append(key, item);
+        combinedParameters.append(`${key}[]`, item);
       });
     } else {
       combinedParameters.append(key, parameter);


### PR DESCRIPTION
As the comment says, array query parameter names should end with `[]`.