### PR TITLE
Add example filtering by incident status

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,11 @@ pd.get('/incidents')
   .then({data, resource, next} => console.log(data, resource, next))
   .catch(console.error);
 
+// Filtering by incident status
+pd.get('/incidents', { queryParameters: { 'statuses[]': ['triggered'] } })
+  .then({data, resource, next} => console.log(data, resource, next))
+  .catch(console.error);
+
 // Similarly, for `post`, `put`, `patch` and `delete`.
 pd.post('/incidents', { data: { ... } }).then(...);
 


### PR DESCRIPTION
When migrating from `node-pagerduty` it wasn't immediately obvious to me how to add the necessary query parameters to filter by status and service_id. 

This PR adds a simple example filter by `status == triggered` which should hopefully point others in the right direction.