### PR TITLE
SEC-6985 Add Snyk Scans in CircleCI (NPM)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  snyk: pagerduty/snyk@2  # https://circleci.com/developer/orbs/orb/pagerduty/snyk
+
 executors:
   base:
     docker:
@@ -65,3 +68,8 @@ workflows:
       - build
       - lint
       - test
+      - snyk/snyk_test_full_scan:
+          organization: shared-foundations
+          context:
+            - PagerDuty
+            - Snyk


### PR DESCRIPTION
## Context
This PR will enable Snyk Open Source scans in CircleCI.  

Changes Include:

1. Updating the CircleCI config.yml to add the PagerDuty Snyk orb, and adding the Job to run that scan


## Engineering Team Code Owners Should Test, Validate, and Merge

Please update as needed and merge these PRs when you feel comfortable to do so. 
We are asking the teams that own each repository to carefully test and merge these changes so they can monitor for any resulting issues, as they are more familiar with the code and deploy process.

## Checklist for Team Code Owners
- [ ] Ensure that all builds are successful.
- [ ] Check review for any comments/addendums from Product Security that might need to be manually addressed.
- [ ] Approve and MERGE the PR when ready!

## Checklist for Product Security

### Snyk WebUI
- [x] The Snyk WebUI has been reviewed to ensure the repo is now showing up as expected
- [x] There are no duplicate findings in the WebUI (ex: there's already a Github integration for non-Elixir dependencies)

### CircleCI
- [x] Ensure all builds still complete
- [x] The Snyk scan is not failing due to an error with the scan
- [x] The Snyk scan is either passing or failing due to vulnerabilities
- [x] The Snyk scan is detecting the expected package manager files (based on reviewing what's in the repo)

