### PR TITLE
docs(pdjs): add Source Code Repository Link

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "@pagerduty/pdjs",
   "version": "2.2.4",
   "description": "A new simple JavaScript wrapper for the PagerDuty API",
+  "repository": "PagerDuty/pdjs",
   "main": "build/src/index.js",
   "types": "build/src/index.d.ts",
   "files": [


### PR DESCRIPTION
Enhances package documentation by linking the npm package to its source code repository. This facilitates easier navigation for users and improves the efficiency of automated tools in analyzing the package.

# Summary

Add repo link so that the source code link can be visible in the [npmjs.com](https://www.npmjs.com/package/@pagerduty/pdjs) ui.

# Related Issues/PRs